### PR TITLE
New Features: Defect Introduced Date and Author with delimited email

### DIFF
--- a/src/main/java/org/sonar/plugins/issueassign/Assign.java
+++ b/src/main/java/org/sonar/plugins/issueassign/Assign.java
@@ -37,7 +37,7 @@ public class Assign {
 
   public Assign(final Settings settings, final UserFinder userFinder) {
     this.settings = settings;
-    this.users = new Users(userFinder);
+    this.users = new Users(userFinder, settings);
   }
 
   public User getAssignee(final String scmAuthor) throws IssueAssignPluginException {

--- a/src/main/java/org/sonar/plugins/issueassign/Blame.java
+++ b/src/main/java/org/sonar/plugins/issueassign/Blame.java
@@ -38,12 +38,12 @@ public class Blame {
     this.measuresCollector = measuresCollector;
   }
 
-  public String getScmAuthorForIssue(final Issue issue) throws MissingScmMeasureDataException {
+  public String getScmAuthorForIssue(final Issue issue, final boolean assignToAuthor) throws MissingScmMeasureDataException {
 
     final String authorForIssueLine = this.getAuthorForIssueLine(issue);
     final String lastCommitterForResource = getLastCommitterForResource(issue.componentKey());
 
-    if (lastCommitterForResource.equals(authorForIssueLine)) {
+    if (assignToAuthor || lastCommitterForResource.equals(authorForIssueLine)) {
       LOG.debug("Author [" + authorForIssueLine + "] is also the last committer.");
       return authorForIssueLine;
     }

--- a/src/main/java/org/sonar/plugins/issueassign/IssueAssignPlugin.java
+++ b/src/main/java/org/sonar/plugins/issueassign/IssueAssignPlugin.java
@@ -68,7 +68,13 @@ import java.util.List;
     	description = "Some SCM authors may not be formatted in a way that will work with this plug in, so long as the Author contains an email address and is delimited with a start and end charater this pref can be used to find the email in the Author name.",
     	project = true,
     	type = PropertyType.STRING,
-    	defaultValue = "")
+    	defaultValue = ""),
+    @Property(key = IssueAssignPlugin.PROPERTY_ASSIGN_TO_AUTHOR,
+    	name = "Always assign to Author",
+    	description = "Set to true if you want to always assign to the defect author, set to false if you want to assign to the last commiter on the file if they are different from the author.",
+    	project = true,
+    	type = PropertyType.BOOLEAN,
+    	defaultValue = "false")
 })
 public final class IssueAssignPlugin extends SonarPlugin {
 
@@ -78,6 +84,7 @@ public final class IssueAssignPlugin extends SonarPlugin {
   public static final String PROPERTY_DEFECT_ITRODUCED_DATE = "defect.introduced";
   public static final String PROPERTY_EMAIL_START_CHAR = "email.start.char";
   public static final String PROPERTY_EMAIL_END_CHAR = "email.end.char";
+  public static final String PROPERTY_ASSIGN_TO_AUTHOR = "assigne.to.last.commiter";
 
   public List getExtensions() {
     return Arrays.asList(MeasuresCollector.class,

--- a/src/main/java/org/sonar/plugins/issueassign/IssueAssignPlugin.java
+++ b/src/main/java/org/sonar/plugins/issueassign/IssueAssignPlugin.java
@@ -23,9 +23,11 @@ import org.sonar.api.Properties;
 import org.sonar.api.Property;
 import org.sonar.api.PropertyType;
 import org.sonar.api.SonarPlugin;
+import org.sonar.plugins.issueassign.IssueAssigner;
 import org.sonar.plugins.issueassign.measures.MeasuresCollector;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -48,13 +50,34 @@ import java.util.List;
         description = "Enable or disable the Issue Assign plugin.",
         project = true,
         type = PropertyType.BOOLEAN,
-        defaultValue = "false")
+        defaultValue = "false"),
+    @Property(key = IssueAssignPlugin.PROPERTY_DEFECT_ITRODUCED_DATE,
+    	name = "Defect introduced date",
+    	description = "Any defects introduced or updated after this date are auto assigned, any defects before will be ignored. Use the format 03/22/2010 (mm/dd/yyyy)",
+    	project = true, 
+    	type = PropertyType.STRING, 
+    	defaultValue = ""),
+    @Property(key = IssueAssignPlugin.PROPERTY_EMAIL_START_CHAR,
+    	name = "Author email start character",
+    	description = "Some SCM authors may not be formatted in a way that will work with this plug in, so long as the Author contains an email address and is delimited with a start and end charater this pref can be used to find the email in the Author name.",
+    	project = true,
+    	type = PropertyType.STRING,
+    	defaultValue = ""),
+    @Property(key = IssueAssignPlugin.PROPERTY_EMAIL_END_CHAR,
+    	name = "Author email end character",
+    	description = "Some SCM authors may not be formatted in a way that will work with this plug in, so long as the Author contains an email address and is delimited with a start and end charater this pref can be used to find the email in the Author name.",
+    	project = true,
+    	type = PropertyType.STRING,
+    	defaultValue = "")
 })
 public final class IssueAssignPlugin extends SonarPlugin {
 
   public static final String PROPERTY_DEFAULT_ASSIGNEE = "default.assignee";
   public static final String PROPERTY_OVERRIDE_ASSIGNEE = "override.assignee";
   public static final String PROPERTY_ENABLED = "issueassignplugin.enabled";
+  public static final String PROPERTY_DEFECT_ITRODUCED_DATE = "defect.introduced";
+  public static final String PROPERTY_EMAIL_START_CHAR = "email.start.char";
+  public static final String PROPERTY_EMAIL_END_CHAR = "email.end.char";
 
   public List getExtensions() {
     return Arrays.asList(MeasuresCollector.class,

--- a/src/main/java/org/sonar/plugins/issueassign/IssueAssigner.java
+++ b/src/main/java/org/sonar/plugins/issueassign/IssueAssigner.java
@@ -55,8 +55,8 @@ public class IssueAssigner implements IssueHandler {
     }
 
     final Issue issue = context.issue();
-
-    //TODO not sure this check is necessary
+    
+    //Make sure the issue is only assigned if new or if it was introduced after the introduced date.
     if (issue.isNew() || (issueAfterDefectIntroducedDate(issue) && issue.assignee() == null)) {
       LOG.debug("Found new issue [" + issue.key() + "]");
       try {
@@ -100,7 +100,8 @@ public class IssueAssigner implements IssueHandler {
 
   private void assignIssue(final Context context, final Issue issue) throws IssueAssignPluginException {
 
-    final String author = blame.getScmAuthorForIssue(issue);
+	final boolean assignToAuthor = this.settings.getBoolean(IssueAssignPlugin.PROPERTY_ASSIGN_TO_AUTHOR);
+    final String author = blame.getScmAuthorForIssue(issue, assignToAuthor);
     final User assignee;
 
     if (author == null) {

--- a/src/main/java/org/sonar/plugins/issueassign/IssueAssigner.java
+++ b/src/main/java/org/sonar/plugins/issueassign/IssueAssigner.java
@@ -57,7 +57,7 @@ public class IssueAssigner implements IssueHandler {
     final Issue issue = context.issue();
 
     //TODO not sure this check is necessary
-    if (issue.isNew() || issueAfterDefectIntroducedDate(issue)) {
+    if (issue.isNew() || (issueAfterDefectIntroducedDate(issue) && issue.assignee() == null)) {
       LOG.debug("Found new issue [" + issue.key() + "]");
       try {
         this.assignIssue(context, issue);

--- a/src/test/java/org/sonar/plugins/issueassign/BlameTest.java
+++ b/src/test/java/org/sonar/plugins/issueassign/BlameTest.java
@@ -97,7 +97,7 @@ public class BlameTest {
     when(mockIssue.line()).thenReturn(1);
 
     final Blame classUnderTest = new Blame(mockMeasuresCollector);
-    final String author = classUnderTest.getScmAuthorForIssue(mockIssue);
+    final String author = classUnderTest.getScmAuthorForIssue(mockIssue, false);
     assertThat(author).isEqualTo(AUTHOR1);
   }
 
@@ -125,7 +125,7 @@ public class BlameTest {
     when(mockIssue.line()).thenReturn(1);
 
     final Blame classUnderTest = new Blame(mockMeasuresCollector);
-    final String author = classUnderTest.getScmAuthorForIssue(mockIssue);
+    final String author = classUnderTest.getScmAuthorForIssue(mockIssue, false);
     assertThat(author).isEqualTo(AUTHOR3);
   }
 
@@ -135,7 +135,7 @@ public class BlameTest {
     when(scmMeasures.getAuthorsByLine()).thenReturn(null);
 
     final Blame classUnderTest = new Blame(mockMeasuresCollector);
-    classUnderTest.getScmAuthorForIssue(mockIssue);
+    classUnderTest.getScmAuthorForIssue(mockIssue, false);
   }
 
   @Test(expected = NoUniqueAuthorForLastCommitException.class)
@@ -160,7 +160,7 @@ public class BlameTest {
     when(mockIssue.line()).thenReturn(1);
 
     final Blame classUnderTest = new Blame(mockMeasuresCollector);
-    final String author = classUnderTest.getScmAuthorForIssue(mockIssue);
+    final String author = classUnderTest.getScmAuthorForIssue(mockIssue, false);
     assertThat(author).isEqualTo(AUTHOR3);
   }
 }

--- a/src/test/java/org/sonar/plugins/issueassign/IssueAssignerTest.java
+++ b/src/test/java/org/sonar/plugins/issueassign/IssueAssignerTest.java
@@ -19,6 +19,9 @@
  */
 package org.sonar.plugins.issueassign;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -49,6 +52,7 @@ public class IssueAssignerTest {
   private static final String COMPONENT_KEY = "str1:str2:str3";
   private static final String PROJECT_KEY = "str1:str2";
   private static final String SCM_AUTHOR = "author";
+  private static final String SCM_AUTHOR_WITH_EMAIL = "author <email@test.com>";
   private static final String ISSUE_KEY = "issueKey";
 
   @Test
@@ -57,6 +61,50 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(issue.isNew()).thenReturn(false);
+
+    final IssueHandler classUnderTest =
+        new org.sonar.plugins.issueassign.IssueAssigner(measuresCollector, settings, userFinder);
+    Whitebox.setInternalState(classUnderTest, "blame", blame);
+    Whitebox.setInternalState(classUnderTest, "assign", assign);
+    classUnderTest.onIssue(context);
+  }
+  
+  @Test
+  public void testOnIssueCreationDate() throws Exception {
+	
+	SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy");
+	Date d = df.parse("04/03/2014");
+    when(context.issue()).thenReturn(issue);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
+    when(settings.getString(IssueAssignPlugin.PROPERTY_DEFECT_ITRODUCED_DATE)).thenReturn("04/02/2014");
+    when(blame.getScmAuthorForIssue(issue)).thenReturn(SCM_AUTHOR_WITH_EMAIL);
+    when(settings.getString(IssueAssignPlugin.PROPERTY_EMAIL_START_CHAR)).thenReturn("<");
+    when(settings.getString(IssueAssignPlugin.PROPERTY_EMAIL_END_CHAR)).thenReturn(">");
+    when(assign.getAssignee(SCM_AUTHOR_WITH_EMAIL)).thenReturn(assignee);
+    when(issue.isNew()).thenReturn(false);
+    when(issue.creationDate()).thenReturn(d);
+
+    final IssueHandler classUnderTest =
+        new org.sonar.plugins.issueassign.IssueAssigner(measuresCollector, settings, userFinder);
+    Whitebox.setInternalState(classUnderTest, "blame", blame);
+    Whitebox.setInternalState(classUnderTest, "assign", assign);
+    Whitebox.setInternalState(classUnderTest, "settings", settings);
+    classUnderTest.onIssue(context);
+  }
+  
+  @Test
+  public void testOnIssueCreationDate2() throws Exception {
+	
+	SimpleDateFormat df = new SimpleDateFormat("MM/dd/yyyy");
+	Date d = df.parse("04/03/2014");
+    when(context.issue()).thenReturn(issue);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
+    when(settings.getString(IssueAssignPlugin.PROPERTY_DEFECT_ITRODUCED_DATE)).thenReturn("04/05/2014");
+    when(issue.isNew()).thenReturn(false);
+    when(issue.creationDate()).thenReturn(d);
+    when(issue.updateDate()).thenReturn(d);
 
     final IssueHandler classUnderTest =
         new org.sonar.plugins.issueassign.IssueAssigner(measuresCollector, settings, userFinder);

--- a/src/test/java/org/sonar/plugins/issueassign/IssueAssignerTest.java
+++ b/src/test/java/org/sonar/plugins/issueassign/IssueAssignerTest.java
@@ -78,7 +78,7 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(settings.getString(IssueAssignPlugin.PROPERTY_DEFECT_ITRODUCED_DATE)).thenReturn("04/02/2014");
-    when(blame.getScmAuthorForIssue(issue)).thenReturn(SCM_AUTHOR_WITH_EMAIL);
+    when(blame.getScmAuthorForIssue(issue, false)).thenReturn(SCM_AUTHOR_WITH_EMAIL);
     when(settings.getString(IssueAssignPlugin.PROPERTY_EMAIL_START_CHAR)).thenReturn("<");
     when(settings.getString(IssueAssignPlugin.PROPERTY_EMAIL_END_CHAR)).thenReturn(">");
     when(assign.getAssignee(SCM_AUTHOR_WITH_EMAIL)).thenReturn(assignee);
@@ -120,7 +120,7 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(issue.isNew()).thenReturn(true);
-    when(blame.getScmAuthorForIssue(issue)).thenReturn(SCM_AUTHOR);
+    when(blame.getScmAuthorForIssue(issue, false)).thenReturn(SCM_AUTHOR);
     when(issue.key()).thenReturn(ISSUE_KEY);
     when(assign.getAssignee(SCM_AUTHOR)).thenReturn(assignee);
 
@@ -141,7 +141,7 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(issue.isNew()).thenReturn(true);
-    when(blame.getScmAuthorForIssue(issue)).thenReturn(SCM_AUTHOR);
+    when(blame.getScmAuthorForIssue(issue, false)).thenReturn(SCM_AUTHOR);
     when(issue.key()).thenReturn(ISSUE_KEY);
     when(assign.getAssignee(SCM_AUTHOR)).thenThrow(RuntimeException.class);
 
@@ -162,7 +162,7 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(issue.isNew()).thenReturn(true);
-    when(blame.getScmAuthorForIssue(issue)).thenReturn(SCM_AUTHOR);
+    when(blame.getScmAuthorForIssue(issue, false)).thenReturn(SCM_AUTHOR);
     when(issue.key()).thenReturn(ISSUE_KEY);
     when(assign.getAssignee(SCM_AUTHOR)).thenThrow(IssueAssignPluginException.class);
 
@@ -198,7 +198,7 @@ public class IssueAssignerTest {
     when(issue.componentKey()).thenReturn(COMPONENT_KEY);
     when(settings.getBoolean(IssueAssignPlugin.PROPERTY_ENABLED)).thenReturn(true);
     when(issue.isNew()).thenReturn(true);
-    when(blame.getScmAuthorForIssue(issue)).thenReturn(null);
+    when(blame.getScmAuthorForIssue(issue, false)).thenReturn(null);
     when(issue.key()).thenReturn(ISSUE_KEY);
     when(assign.getAssignee()).thenReturn(assignee);
 


### PR DESCRIPTION
This adds two prefs that my company is going to be using. 

Defect Introduced Date: This lets the user set a defect introduced date and when sonar runs it will automatically assign defects when they were created after the date set in the pref. This is useful to us because we have a large existing code base and would like to get all the old defects assigned out. 

Author with Delimited email: This is useful for us because our git Authors have the form: First Last email@email.com because it's not a username or email address your plugin wasn't working for us, I added the pref so we could set the start and end characters for the email address in the author name.

I think these could be useful to others which is why I'm sending them back to you. Please let me know if you have any questions or if there is anything I should do before you can accept this. I'm not familiar with maven or mockito tests but I tried to do my best to keep everything working.

Hardy
